### PR TITLE
Support newer versions of TextExpander.

### DIFF
--- a/textexpander-to-alfred3.js
+++ b/textexpander-to-alfred3.js
@@ -25,12 +25,21 @@ if (!process.argv.slice(2).length) {
 function transformSnippet (snippet) {
   const name = !snippet.label || snippet.label === '' ? snippet.abbreviation.slice(0, 10) : snippet.label
 
+  // First, look for the plain-text snippet.
+  let snippetText = snippet.plainText || false;
+
+  // If no plain-text version exists, attempt to rescue snippet text from TextExpander's serialized JSON.
+  snippetText = JSON.parse(snippet.extraInfo.jsonStr).nodes[0].tx || snippetText;
+
+  // Replace TextExpander tokens with Alfred tokens.
+  snippetText = snippetText.replace(/%clipboard/g, '{clipboard}').replace(/%\|/g, '{cursor}')
+  
   return {
     filename: sanitize(name) + ' [' + snippet.uuidString + '].json',
-    usable: Boolean(snippet.plainText),
+    usable: Boolean(snippetText),
     content: JSON.stringify({
       alfredsnippet: {
-        snippet: snippet.plainText ? snippet.plainText.replace(/%clipboard/g, '{clipboard}').replace(/%\|/g, '{cursor}') : false,
+        snippet: snippetText
         name: name,
         uid: snippet.uuidString,
         keyword: snippet.abbreviation

--- a/textexpander-to-alfred3.js
+++ b/textexpander-to-alfred3.js
@@ -29,7 +29,27 @@ function transformSnippet (snippet) {
   let snippetText = snippet.plainText || false;
 
   // If no plain-text version exists, attempt to rescue snippet text from TextExpander's serialized JSON.
-  snippetText = JSON.parse(snippet.extraInfo.jsonStr).nodes[0].tx || snippetText;
+  if (snippet.extraInfo.jsonStr) {
+    let snippetJSON = JSON.parse(snippet.extraInfo.jsonStr);
+    snippetJSON.nodes.forEach(node => {
+      // Plain text.
+      if (node.e === 'tx') {
+        snippetText += node.tx
+      }
+      // Line break.
+      if (node.e === 'br') {
+        snippetText += '\n';
+      }
+      // Cursor position
+      if (node.e === 'mark-cursor-position') {
+        snippetText += '{cursor}';
+      }
+      // Line break.
+      if (node.e === 'macro-pasteboard') {
+        snippetText += '{clipboard}';
+      }
+    });
+  }
 
   // Replace TextExpander tokens with Alfred tokens.
   snippetText = snippetText.replace(/%clipboard/g, '{clipboard}').replace(/%\|/g, '{cursor}')

--- a/textexpander-to-alfred3.js
+++ b/textexpander-to-alfred3.js
@@ -24,17 +24,13 @@ if (!process.argv.slice(2).length) {
 
 function transformSnippet (snippet) {
   const name = !snippet.label || snippet.label === '' ? snippet.abbreviation.slice(0, 10) : snippet.label
-  let snippetText = snippet.plainText || false;
 
-  // Replace TextExpander tokens with Alfred tokens.
-  snippetText = snippetText.replace(/%clipboard/g, '{clipboard}').replace(/%\|/g, '{cursor}')
-  
   return {
     filename: sanitize(name) + ' [' + snippet.uuidString + '].json',
-    usable: Boolean(snippetText),
+    usable: Boolean(snippet.plainText),
     content: JSON.stringify({
       alfredsnippet: {
-        snippet: snippetText
+        snippet: snippet.plainText.replace(/%clipboard/g, '{clipboard}').replace(/%\|/g, '{cursor}'),
         name: name,
         uid: snippet.uuidString,
         keyword: snippet.abbreviation

--- a/textexpander-to-alfred3.js
+++ b/textexpander-to-alfred3.js
@@ -69,7 +69,7 @@ function textexpander2Alfred (plistString) {
 
   // Use the TextExpander 3 snippet collection, if available.
   // The `snippetsTE2` key is included in the v3 snippet plist file
-  // with a warning message in case someone using TextExpande v2 tries
+  // with a warning message in case someone using TextExpander v2 tries
   // to import a v3 snippet file.
   const snippets = parsedPlist.snippetsTE3 || parsedPlist.snippetsTE2
 

--- a/textexpander-to-alfred3.js
+++ b/textexpander-to-alfred3.js
@@ -30,7 +30,7 @@ function transformSnippet (snippet) {
     usable: Boolean(snippet.plainText),
     content: JSON.stringify({
       alfredsnippet: {
-        snippet: snippet.plainText ? snippet.plainText.replace(/%clipboard/g, '{clipboard}') : false,
+        snippet: snippet.plainText ? snippet.plainText.replace(/%clipboard/g, '{clipboard}').replace(/%\|/g, '{cursor}') : false,
         name: name,
         uid: snippet.uuidString,
         keyword: snippet.abbreviation

--- a/textexpander-to-alfred3.js
+++ b/textexpander-to-alfred3.js
@@ -24,32 +24,7 @@ if (!process.argv.slice(2).length) {
 
 function transformSnippet (snippet) {
   const name = !snippet.label || snippet.label === '' ? snippet.abbreviation.slice(0, 10) : snippet.label
-
-  // First, look for the plain-text snippet.
   let snippetText = snippet.plainText || false;
-
-  // If no plain-text version exists, attempt to rescue snippet text from TextExpander's serialized JSON.
-  if (snippet.extraInfo.jsonStr) {
-    let snippetJSON = JSON.parse(snippet.extraInfo.jsonStr);
-    snippetJSON.nodes.forEach(node => {
-      // Plain text.
-      if (node.e === 'tx') {
-        snippetText += node.tx
-      }
-      // Line break.
-      if (node.e === 'br') {
-        snippetText += '\n';
-      }
-      // Cursor position
-      if (node.e === 'mark-cursor-position') {
-        snippetText += '{cursor}';
-      }
-      // Line break.
-      if (node.e === 'macro-pasteboard') {
-        snippetText += '{clipboard}';
-      }
-    });
-  }
 
   // Replace TextExpander tokens with Alfred tokens.
   snippetText = snippetText.replace(/%clipboard/g, '{clipboard}').replace(/%\|/g, '{cursor}')

--- a/textexpander-to-alfred3.js
+++ b/textexpander-to-alfred3.js
@@ -30,7 +30,7 @@ function transformSnippet (snippet) {
     usable: Boolean(snippet.plainText),
     content: JSON.stringify({
       alfredsnippet: {
-        snippet: snippet.plainText.replace(/%clipboard/g, '{clipboard}').replace(/%\|/g, '{cursor}'),
+        snippet: snippet.plainText ? snippet.plainText.replace(/%clipboard/g, '{clipboard}').replace(/%\|/g, '{cursor}') : false,
         name: name,
         uid: snippet.uuidString,
         keyword: snippet.abbreviation

--- a/textexpander-to-alfred3.js
+++ b/textexpander-to-alfred3.js
@@ -67,7 +67,13 @@ function textexpander2Alfred (plistString) {
 
   const archive = archiver('zip')
 
-  parsedPlist.snippetsTE2
+  // Use the TextExpander 3 snippet collection, if available.
+  // The `snippetsTE2` key is included in the v3 snippet plist file
+  // with a warning message in case someone using TextExpande v2 tries
+  // to import a v3 snippet file.
+  const snippets = parsedPlist.snippetsTE3 || parsedPlist.snippetsTE2
+
+  snippets
     .map(transformSnippet)
     .filter((snippet) => {
       return snippet.usable


### PR DESCRIPTION
TextExpander v3 uses a different key for containing its snippets in the `plist` file: `snippetsTE3` instead of `snippetsTE2`. But it *also has* the `snippetsTE2` key so that if someone using TextExpander v2 tries to import a TextExpander v3 snippets file they'll get a useful explanation. E.g.:

**my-snippets.textexpander**
```xml
[...]
</dict>
<key>snippetsTE2</key>
<array>
  <dict>
    <key>plainText</key>
    <string>This group was saved with a newer version of TextExpander.
Update to the current version of TextExpander to read the 5 snippets in this group.
If you need to read the group with an older version of TextExpander, use TextExpander.com to export the group in comma-separated value (CSV) format.</string>
    <key>snippetType</key>
    <integer>0</integer>
  </dict>
</array>
<key>snippetsTE3</key>
<array>
[...]
```

The **textexpander-to-alfred3** script just looks for `snippetsTE2`, because TextExpander v3 didn't exist when it was written.

This PR simply looks for the `snippetsTE3` key first and uses that, falling back to `snippetsTE2` otherwise.

I tested this on my own snippet files and had 100% success with converting and importing 15 different snippet exports of varying complexity.

This (presumably) fixes https://github.com/danieldiekmeier/textexpander-to-alfred3/issues/11 and https://github.com/danieldiekmeier/textexpander-to-alfred3/issues/10 and https://github.com/danieldiekmeier/textexpander-to-alfred3/issues/9, yay!

**NOTE:** For some reason, TextExpander v3 does not export a snippet group's group-level prefix, so you will have to re-do that in Alfred once you import it. **Daniel:** You might want to add this information to the instructions.