### PR TITLE
Convert TE cursor token to Alfred's cursor token.

### DIFF
--- a/textexpander-to-alfred3.js
+++ b/textexpander-to-alfred3.js
@@ -30,7 +30,7 @@ function transformSnippet (snippet) {
     usable: Boolean(snippet.plainText),
     content: JSON.stringify({
       alfredsnippet: {
-        snippet: snippet.plainText ? snippet.plainText.replace(/%clipboard/g, '{clipboard}') : false,
+        snippet: snippet.plainText ? snippet.plainText.replace(/%clipboard/g, '{clipboard}').replace(/%\|/g, '{cursor}') : false,
         name: name,
         uid: snippet.uuidString,
         keyword: snippet.abbreviation


### PR DESCRIPTION
This converts the `%|` token in TextExpander snippets—which means "put the cursor here after expansion"—to `{cursor}`, the Alfred equivalent.

Note that this will not work on newer versions of TextExpander (v6.5+) that use a visual editor for tokens and do not include these in the `plainText` key but only in the `json` key, which is serialized and not easily parsed.